### PR TITLE
[APP-3468] Flask template: Rename exec env 3.12 App Base

### DIFF
--- a/template_info.json
+++ b/template_info.json
@@ -9,11 +9,11 @@
     ],
     "source": {
       "repositoryUrl": "https://github.com/datarobot-oss/flask-app-base",
-      "releaseTag": "10.2.1"
+      "releaseTag": "10.2.2"
     },
     "previewImage": null
   },
   "templateType": "customApplicationTemplate",
   "templateSubType": "customApplicationTemplate",
-  "executionEnvironmentName": "[DataRobot] Python 3.12"
+  "executionEnvironmentName": "[DataRobot] Python 3.12 Applications Base"
 }


### PR DESCRIPTION
## This repository is public. Do not put any private DataRobot or customer data: code, datasets, model artifacts, .etc.

## Rationale

The base execution environment is getting renamed. Update the template_info and bump the version

