### PR TITLE
Extend Flask template

### DIFF
--- a/src/flask_app.py
+++ b/src/flask_app.py
@@ -1,25 +1,117 @@
 import logging
 import os
+from datetime import datetime, timezone
+from urllib.parse import urlparse
 
-from datarobot import Client
-from datarobot.client import set_client
-from flask import Flask, render_template
+import yaml
+import requests
+from flask import Flask, jsonify, render_template, request
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 logger = logging.getLogger(__name__)
 
-# Setup DR client
-DR_TOKEN = os.getenv("token")
-DR_ENDPOINT = os.getenv("endpoint")
-set_client(Client(token=DR_TOKEN, endpoint=DR_ENDPOINT))
+# DataRobot credentials injected by the platform
+DR_TOKEN = os.getenv("DATAROBOT_API_TOKEN")
+DR_ENDPOINT = os.getenv("DATAROBOT_ENDPOINT", "").rstrip("/")
+
+# Derive the cluster-specific API docs URL (e.g. https://app.datarobot.com/apidocs/)
+_parsed = urlparse(DR_ENDPOINT)
+DR_APIDOCS_URL = f"{_parsed.scheme}://{_parsed.netloc}/apidocs/" if _parsed.netloc else None
+
+# BASE_PATH is injected by the DataRobot platform (e.g. "custom_applications/abc123").
+# Setting SCRIPT_NAME makes url_for() generate prefix-aware URLs.
+_BASE_PATH = os.getenv("BASE_PATH", "").strip("/")
+_SCRIPT_NAME = f"/{_BASE_PATH}" if _BASE_PATH else ""
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
-flask_app = Flask(__name__, template_folder=os.path.join(base_dir, 'templates'))
-flask_app.wsgi_app = ProxyFix(flask_app.wsgi_app, x_prefix=1)
+flask_app = Flask(__name__, template_folder=os.path.join(base_dir, "templates"))
+
+# ProxyFix handles X-Forwarded-For / X-Forwarded-Proto from the reverse proxy.
+# We deliberately omit x_prefix — the prefix is sourced from BASE_PATH instead.
+flask_app.wsgi_app = ProxyFix(flask_app.wsgi_app, x_for=1, x_proto=1)
+
+if _SCRIPT_NAME:
+    _inner = flask_app.wsgi_app
+    def _script_name_middleware(environ, start_response, _app=_inner, _sn=_SCRIPT_NAME):
+        environ["SCRIPT_NAME"] = _sn
+        return _app(environ, start_response)
+    flask_app.wsgi_app = _script_name_middleware
+
+# OpenAPI spec is defined in openapi.yaml — edit that file to document new routes
+with open(os.path.join(base_dir, "openapi.yaml")) as _f:
+    OPENAPI_SPEC = yaml.safe_load(_f)
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _proxy(path):
+    """Proxy a GET request to the DataRobot API."""
+    try:
+        url = f"{DR_ENDPOINT}/{path.lstrip('/')}"
+        resp = requests.get(
+            url,
+            headers={"Authorization": f"Bearer {DR_TOKEN}"},
+            params=request.args.to_dict() or None,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return jsonify(resp.json())
+    except requests.HTTPError as exc:
+        return jsonify({"error": str(exc)}), exc.response.status_code
+    except Exception as exc:
+        logger.exception("Error proxying %s", path)
+        return jsonify({"error": str(exc)}), 500
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
 
 @flask_app.route("/")
-def index_route():
-    return render_template("index.html", message="Hello from Flask")
+def index():
+    return render_template("index.html", dr_apidocs_url=DR_APIDOCS_URL)
+
+
+@flask_app.route("/health")
+def health():
+    return jsonify({"status": "ok", "timestamp": datetime.now(timezone.utc).isoformat()})
+
+
+@flask_app.route("/api/me")
+def api_me():
+    return _proxy("/account/info/")
+
+
+@flask_app.route("/api/projects")
+def api_projects():
+    return _proxy("/projects/")
+
+
+@flask_app.route("/api/deployments")
+def api_deployments():
+    return _proxy("/deployments/")
+
+
+@flask_app.route("/api/use-cases")
+def api_use_cases():
+    return _proxy("/useCases/")
+
+
+@flask_app.route("/api/version")
+def api_version():
+    return _proxy("/version/")
+
+
+@flask_app.route("/openapi.json")
+def openapi_spec():
+    return jsonify(OPENAPI_SPEC)
+
+
+@flask_app.route("/apidocs")
+def apidocs():
+    return render_template("apidocs.html")
+
 
 if __name__ == "__main__":
     flask_app.run(host="0.0.0.0", debug=False, port=8080)

--- a/src/flask_app.py
+++ b/src/flask_app.py
@@ -105,7 +105,9 @@ def api_version():
 
 @flask_app.route("/openapi.json")
 def openapi_spec():
-    return jsonify(OPENAPI_SPEC)
+    spec = dict(OPENAPI_SPEC)
+    spec["servers"] = [{"url": request.url_root.rstrip("/")}]
+    return jsonify(spec)
 
 
 @flask_app.route("/apidocs")

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1,0 +1,78 @@
+openapi: "3.0.0"
+
+info:
+  title: Flask Application Template
+  version: "1.0.0"
+  description: >
+    Example API built on the DataRobot Flask template.
+    Endpoints proxy the DataRobot public API using the
+    application-scoped token injected by the platform.
+
+paths:
+  /health:
+    get:
+      summary: Application health check
+      tags: [Health]
+      responses:
+        "200":
+          description: Application is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                  timestamp:
+                    type: string
+                    example: "2025-01-01T00:00:00+00:00"
+
+  /api/me:
+    get:
+      summary: Current account information
+      tags: [DataRobot]
+      responses:
+        "200":
+          description: Account info for the token owner
+
+  /api/projects:
+    get:
+      summary: List DataRobot projects
+      tags: [DataRobot]
+      parameters:
+        - { name: limit, in: query, schema: { type: integer } }
+        - { name: offset, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: Paginated list of projects
+
+  /api/deployments:
+    get:
+      summary: List DataRobot deployments
+      tags: [DataRobot]
+      parameters:
+        - { name: limit, in: query, schema: { type: integer } }
+        - { name: offset, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: Paginated list of deployments
+
+  /api/use-cases:
+    get:
+      summary: List DataRobot use cases
+      tags: [DataRobot]
+      parameters:
+        - { name: limit, in: query, schema: { type: integer } }
+        - { name: offset, in: query, schema: { type: integer } }
+      responses:
+        "200":
+          description: Paginated list of use cases
+
+  /api/version:
+    get:
+      summary: DataRobot API version information
+      tags: [DataRobot]
+      responses:
+        "200":
+          description: API version details

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,4 @@
-flask>=3.0.3
-gunicorn>=23.0.0
-datarobot>=3.5.2
+flask>=3.1.3,<3.2.0
+pyyaml>=6.0
+gunicorn>=25.2.0,<26.0.0
+requests>=2.33.0,<2.34.0

--- a/src/start-app.sh
+++ b/src/start-app.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 echo "Starting App"
 
-export token="$DATAROBOT_API_TOKEN"
-export endpoint="$DATAROBOT_ENDPOINT"
+# Default to 4 workers — nproc is unreliable in containers because it reports
+# the host CPU count, not the container's CPU limit, causing runaway worker
+# counts and OOM kills. Override via GUNICORN_WORKERS if needed.
+WORKERS=${GUNICORN_WORKERS:-4}
 
-gunicorn -b :8080 flask_app:flask_app  --timeout 200 --graceful-timeout 30
+exec gunicorn flask_app:flask_app \
+  --bind :8080 \
+  --workers "${WORKERS}" \
+  --timeout 200 \
+  --graceful-timeout 30 \
+  --access-logfile - \
+  --error-logfile -

--- a/src/templates/apidocs.html
+++ b/src/templates/apidocs.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>API Docs — Flask Application Template</title>
+  <link rel="icon" href="https://www.datarobot.com/favicon.ico" />
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+    SwaggerUIBundle({
+      url: '{{ url_for("openapi_spec") }}',
+      dom_id: '#swagger-ui',
+      presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
+      layout: 'BaseLayout',
+      deepLinking: true,
+    });
+  </script>
+</body>
+</html>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,25 +1,246 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.png') }}">
-    <title>Flask Template</title>
-    <style>
-        html,body {
-            font-family: sans-serif;
-            display: grid;
-            justify-content: center;
-        }
-        .container {
-            padding-top: 4rem;
-            max-width: 40rem;
-        }
-    </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Flask Application Template</title>
+  <link rel="icon" href="https://www.datarobot.com/favicon.ico" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Syntax highlight colours used by the JS highlighter -->
+  <style>
+    .hl-key  { color: #7dd3fc; }
+    .hl-str  { color: #86efac; }
+    .hl-num  { color: #fcd34d; }
+    .hl-bool { color: #f9a8d4; }
+    .hl-null { color: #94a3b8; }
+  </style>
 </head>
-<body>
-<div class="container">
-    <h1>{{ message }}</h1>
-</div>
+<body class="bg-gray-50 text-gray-900 text-sm antialiased">
+
+<!-- Header -->
+<header class="bg-white border-b border-gray-200 px-8 py-3 flex items-center gap-3">
+  <h1 class="font-semibold text-[15px]">Flask Application Template</h1>
+  <span class="text-[11px] font-bold uppercase tracking-widest bg-indigo-100 text-indigo-600 px-2 py-0.5 rounded-full">DataRobot</span>
+</header>
+
+<main class="max-w-3xl mx-auto px-6 py-10 space-y-8">
+
+  <!-- Hero -->
+  <div class="bg-white border border-gray-200 rounded-xl p-8 shadow-sm">
+    <h2 class="text-xl font-semibold mb-2">Getting started</h2>
+    <p class="text-gray-500 max-w-[62ch] leading-relaxed">
+      This template gives you a working Flask application connected to the DataRobot platform.
+      The application token is injected automatically — no manual authentication needed.
+    </p>
+    <p class="text-gray-500 max-w-[62ch] leading-relaxed mt-2">
+      Add your own routes, call the DataRobot API through the built-in proxy endpoints,
+      and explore the full API surface via the Swagger docs below.
+    </p>
+  </div>
+
+  <!-- Endpoints -->
+  <section>
+    <h2 class="text-[11px] font-bold uppercase tracking-widest text-gray-400 mb-3">Endpoints</h2>
+    <div class="grid grid-cols-2 sm:grid-cols-3 gap-2">
+
+      <a href="{{ url_for('health') }}" class="flex flex-col gap-1 bg-white border border-gray-200 rounded-xl p-4 shadow-sm hover:shadow-md hover:bg-gray-50 transition-all no-underline text-inherit">
+        <span class="text-[10px] font-bold uppercase tracking-wider text-green-700 bg-green-100 px-1.5 py-0.5 rounded self-start">GET</span>
+        <span class="font-mono font-semibold text-[13px]">/health</span>
+        <span class="text-gray-400 text-xs">Application health check</span>
+      </a>
+
+      <a href="{{ url_for('api_me') }}" class="flex flex-col gap-1 bg-white border border-gray-200 rounded-xl p-4 shadow-sm hover:shadow-md hover:bg-gray-50 transition-all no-underline text-inherit">
+        <span class="text-[10px] font-bold uppercase tracking-wider text-green-700 bg-green-100 px-1.5 py-0.5 rounded self-start">GET</span>
+        <span class="font-mono font-semibold text-[13px]">/api/me</span>
+        <span class="text-gray-400 text-xs">Current account info</span>
+      </a>
+
+      <a href="{{ url_for('api_projects') }}" class="flex flex-col gap-1 bg-white border border-gray-200 rounded-xl p-4 shadow-sm hover:shadow-md hover:bg-gray-50 transition-all no-underline text-inherit">
+        <span class="text-[10px] font-bold uppercase tracking-wider text-green-700 bg-green-100 px-1.5 py-0.5 rounded self-start">GET</span>
+        <span class="font-mono font-semibold text-[13px]">/api/projects</span>
+        <span class="text-gray-400 text-xs">List projects</span>
+      </a>
+
+      <a href="{{ url_for('api_deployments') }}" class="flex flex-col gap-1 bg-white border border-gray-200 rounded-xl p-4 shadow-sm hover:shadow-md hover:bg-gray-50 transition-all no-underline text-inherit">
+        <span class="text-[10px] font-bold uppercase tracking-wider text-green-700 bg-green-100 px-1.5 py-0.5 rounded self-start">GET</span>
+        <span class="font-mono font-semibold text-[13px]">/api/deployments</span>
+        <span class="text-gray-400 text-xs">List deployments</span>
+      </a>
+
+      <a href="{{ url_for('api_use_cases') }}" class="flex flex-col gap-1 bg-white border border-gray-200 rounded-xl p-4 shadow-sm hover:shadow-md hover:bg-gray-50 transition-all no-underline text-inherit">
+        <span class="text-[10px] font-bold uppercase tracking-wider text-green-700 bg-green-100 px-1.5 py-0.5 rounded self-start">GET</span>
+        <span class="font-mono font-semibold text-[13px]">/api/use-cases</span>
+        <span class="text-gray-400 text-xs">List use cases</span>
+      </a>
+
+      <a href="{{ url_for('apidocs') }}" class="flex flex-col gap-1 bg-white border border-gray-200 rounded-xl p-4 shadow-sm hover:shadow-md hover:bg-gray-50 transition-all no-underline text-inherit">
+        <span class="text-[10px] font-bold uppercase tracking-wider text-indigo-600 bg-indigo-100 px-1.5 py-0.5 rounded self-start">DOCS</span>
+        <span class="font-mono font-semibold text-[13px]">/apidocs</span>
+        <span class="text-gray-400 text-xs">Interactive Swagger UI</span>
+      </a>
+
+    </div>
+  </section>
+
+  <!-- API Explorer -->
+  <section>
+    <h2 class="text-[11px] font-bold uppercase tracking-widest text-gray-400 mb-3">API Explorer</h2>
+    <div class="bg-white border border-gray-200 rounded-xl overflow-hidden shadow-sm">
+
+      <!-- Tabs — data-path uses url_for so prefix is correct on any deployment -->
+      <div id="tabs" class="flex overflow-x-auto border-b border-gray-200">
+        <button class="tab shrink-0 px-4 py-2.5 font-mono text-xs font-medium text-indigo-600 border-b-2 border-indigo-500 bg-transparent cursor-pointer"
+                data-path="{{ url_for('health') }}" data-display="/health">GET /health</button>
+        <button class="tab shrink-0 px-4 py-2.5 font-mono text-xs font-medium text-gray-400 border-b-2 border-transparent bg-transparent cursor-pointer hover:text-gray-700"
+                data-path="{{ url_for('api_me') }}" data-display="/api/me">GET /api/me</button>
+        <button class="tab shrink-0 px-4 py-2.5 font-mono text-xs font-medium text-gray-400 border-b-2 border-transparent bg-transparent cursor-pointer hover:text-gray-700"
+                data-path="{{ url_for('api_projects') }}" data-display="/api/projects">GET /api/projects</button>
+        <button class="tab shrink-0 px-4 py-2.5 font-mono text-xs font-medium text-gray-400 border-b-2 border-transparent bg-transparent cursor-pointer hover:text-gray-700"
+                data-path="{{ url_for('api_deployments') }}" data-display="/api/deployments">GET /api/deployments</button>
+        <button class="tab shrink-0 px-4 py-2.5 font-mono text-xs font-medium text-gray-400 border-b-2 border-transparent bg-transparent cursor-pointer hover:text-gray-700"
+                data-path="{{ url_for('api_use_cases') }}" data-display="/api/use-cases">GET /api/use-cases</button>
+        <button class="tab shrink-0 px-4 py-2.5 font-mono text-xs font-medium text-gray-400 border-b-2 border-transparent bg-transparent cursor-pointer hover:text-gray-700"
+                data-path="{{ url_for('api_version') }}" data-display="/api/version">GET /api/version</button>
+      </div>
+
+      <!-- Body -->
+      <div class="p-5">
+        <div class="flex items-center gap-3 mb-4">
+          <span id="url-display" class="flex-1 font-mono text-xs text-gray-400 bg-gray-50 border border-gray-200 rounded-md px-3 py-2 truncate">/health</span>
+          <button id="send-btn" onclick="sendRequest()" class="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white text-xs font-semibold rounded-md transition-colors cursor-pointer">Send</button>
+        </div>
+        <div class="bg-slate-900 rounded-lg p-4 min-h-[120px]">
+          <div id="response-meta" class="hidden flex items-center gap-2 mb-2">
+            <span id="status-pill" class="font-mono text-[11px] font-bold px-1.5 py-0.5 rounded"></span>
+            <span id="time-label" class="text-xs text-slate-400"></span>
+          </div>
+          <pre id="response-pre" class="font-mono text-xs text-slate-500 italic whitespace-pre-wrap break-words">Hit "Send" to try the endpoint.</pre>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- DataRobot Resources -->
+  <section>
+    <h2 class="text-[11px] font-bold uppercase tracking-widest text-gray-400 mb-3">DataRobot Resources</h2>
+    <div class="flex flex-col gap-2">
+
+      <a href="https://docs.datarobot.com/en/docs/wb-apps/app-templates/index.html" target="_blank" rel="noreferrer"
+         class="flex items-center gap-3 bg-white border border-gray-200 rounded-xl px-4 py-3.5 shadow-sm hover:shadow-md hover:bg-gray-50 transition-all no-underline text-inherit">
+        <span class="text-lg">📖</span>
+        <span class="flex-1">
+          <div class="font-semibold text-[13px]">Application Templates</div>
+          <div class="text-xs text-gray-400">docs.datarobot.com/en/docs/wb-apps/app-templates</div>
+        </span>
+        <span class="text-gray-300 text-sm">↗</span>
+      </a>
+
+      <a href="https://docs.datarobot.com/en/docs/api/reference/public-api/custom_applications.html" target="_blank" rel="noreferrer"
+         class="flex items-center gap-3 bg-white border border-gray-200 rounded-xl px-4 py-3.5 shadow-sm hover:shadow-md hover:bg-gray-50 transition-all no-underline text-inherit">
+        <span class="text-lg">⚙️</span>
+        <span class="flex-1">
+          <div class="font-semibold text-[13px]">Custom Application API Reference</div>
+          <div class="text-xs text-gray-400">docs.datarobot.com/en/docs/api/reference/public-api/custom_applications</div>
+        </span>
+        <span class="text-gray-300 text-sm">↗</span>
+      </a>
+
+      {% if dr_apidocs_url %}
+      <a href="{{ dr_apidocs_url }}" target="_blank" rel="noreferrer"
+         class="flex items-center gap-3 bg-white border border-gray-200 rounded-xl px-4 py-3.5 shadow-sm hover:shadow-md hover:bg-gray-50 transition-all no-underline text-inherit">
+        <span class="text-lg">🔌</span>
+        <span class="flex-1">
+          <div class="font-semibold text-[13px]">DataRobot Public API Reference</div>
+          <div class="text-xs text-gray-400">Interactive Swagger docs for your DataRobot cluster</div>
+        </span>
+        <span class="text-gray-300 text-sm">↗</span>
+      </a>
+      {% endif %}
+
+    </div>
+  </section>
+
+</main>
+
+<script>
+  // activePath holds the full URL-for-resolved path (prefix-aware)
+  let activePath = '{{ url_for("health") }}';
+
+  document.querySelectorAll('.tab').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.tab').forEach(b => {
+        b.classList.remove('text-indigo-600', 'border-indigo-500');
+        b.classList.add('text-gray-400', 'border-transparent');
+      });
+      btn.classList.add('text-indigo-600', 'border-indigo-500');
+      btn.classList.remove('text-gray-400', 'border-transparent');
+      activePath = btn.dataset.path;
+      // Show the short display path, not the full prefixed URL
+      document.getElementById('url-display').textContent = btn.dataset.display;
+      document.getElementById('response-meta').classList.add('hidden');
+      const pre = document.getElementById('response-pre');
+      pre.className = 'font-mono text-xs text-slate-500 italic whitespace-pre-wrap break-words';
+      pre.innerHTML = 'Hit "Send" to try the endpoint.';
+    });
+  });
+
+  function highlight(json) {
+    return JSON.stringify(json, null, 2)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/("(?:\\u[a-fA-F0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(?:true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, m => {
+        if (/^"/.test(m)) return /:$/.test(m) ? `<span class="hl-key">${m}</span>` : `<span class="hl-str">${m}</span>`;
+        if (/true|false/.test(m)) return `<span class="hl-bool">${m}</span>`;
+        if (/null/.test(m)) return `<span class="hl-null">${m}</span>`;
+        return `<span class="hl-num">${m}</span>`;
+      });
+  }
+
+  async function sendRequest() {
+    const btn = document.getElementById('send-btn');
+    const pre = document.getElementById('response-pre');
+    const meta = document.getElementById('response-meta');
+    const pill = document.getElementById('status-pill');
+    const timeLabel = document.getElementById('time-label');
+
+    btn.disabled = true;
+    btn.textContent = '…';
+    pre.className = 'font-mono text-xs text-slate-500 italic whitespace-pre-wrap break-words';
+    pre.innerHTML = 'Loading…';
+    meta.classList.add('hidden');
+
+    const t0 = performance.now();
+    try {
+      const resp = await fetch(activePath);
+      const ms = Math.round(performance.now() - t0);
+      const text = await resp.text();
+
+      pill.textContent = resp.status;
+      pill.className = resp.ok
+        ? 'font-mono text-[11px] font-bold px-1.5 py-0.5 rounded bg-green-900 text-green-300'
+        : 'font-mono text-[11px] font-bold px-1.5 py-0.5 rounded bg-red-900 text-red-300';
+      timeLabel.textContent = `${ms} ms`;
+      meta.classList.remove('hidden');
+      pre.className = 'font-mono text-xs text-slate-300 whitespace-pre-wrap break-words';
+      try {
+        pre.innerHTML = highlight(JSON.parse(text));
+      } catch {
+        pre.textContent = text;
+      }
+    } catch (err) {
+      const ms = Math.round(performance.now() - t0);
+      pill.textContent = 'ERR';
+      pill.className = 'font-mono text-[11px] font-bold px-1.5 py-0.5 rounded bg-red-900 text-red-300';
+      timeLabel.textContent = `${ms} ms`;
+      meta.classList.remove('hidden');
+      pre.className = 'font-mono text-xs text-red-400 whitespace-pre-wrap break-words';
+      pre.textContent = String(err);
+    } finally {
+      btn.disabled = false;
+      btn.textContent = 'Send';
+    }
+  }
+</script>
+
 </body>
 </html>

--- a/template_info.json
+++ b/template_info.json
@@ -9,7 +9,7 @@
     ],
     "source": {
       "repositoryUrl": "https://github.com/datarobot-oss/flask-app-base",
-      "releaseTag": "11.0.0"
+      "releaseTag": "11.6.0"
     },
     "previewImage": null
   },


### PR DESCRIPTION
## Rationale

Provide basic examples on DataRobot API calls and available functions.

### Summary of Changes

<img width="781" height="1169" alt="home" src="https://github.com/user-attachments/assets/b53e468a-017a-46f0-9758-a94930790a6c" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new HTTP proxying to the DataRobot API (Authorization header forwarding) and changes URL prefix/proxy behavior via `SCRIPT_NAME`, which could affect routing and request handling in deployments.
> 
> **Overview**
> Extends the Flask template from a static hello page to a small API-enabled app, adding `/health` plus several **read-only** DataRobot proxy endpoints (`/api/me`, `/api/projects`, `/api/deployments`, `/api/use-cases`, `/api/version`) implemented via `requests` using the platform-injected token.
> 
> Adds an OpenAPI definition (`openapi.yaml`) served at `/openapi.json` and a new Swagger UI page at `/apidocs`, and revamps `index.html` into a Tailwind-based landing page with an in-browser API explorer.
> 
> Updates runtime/setup: drops the `datarobot` SDK in favor of `requests`/`pyyaml`, bumps `flask`/`gunicorn` versions, improves `start-app.sh` with safer bash settings, configurable worker count, and access/error logging to stdout/stderr, and updates template metadata to `11.6.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3462fd87f861a3617bb38340be8a904e3100909b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->